### PR TITLE
Fix JIRA-419 - Inconsistent classpaths when using a base binding file in CodeGen

### DIFF
--- a/build/src/org/jibx/schema/codegen/CodeGen.java
+++ b/build/src/org/jibx/schema/codegen/CodeGen.java
@@ -1748,6 +1748,8 @@ public class CodeGen
                             url = ClasspathUrlExtender.buildURL(null, path);
                         } else {
                             file = new File(path);
+                            if (!file.isAbsolute())
+                                file = new File(m_targetDir, path);
                             url = file.toURI().toURL();
                         }
                         try {


### PR DESCRIPTION
Dennis,
This patch will fix the bugs listed in JIRA-419
There are two commits:
1. If the binding file location is at or below the target directory, don't include the target directory name.
(I'm positive this is a bug)
2. If the binding location is relative, make it relative to the target dir.
(I don't see this breaking any existing code)
Don
