### PR TITLE
Binding file resolution broken on Windows

### DIFF
--- a/build/src/org/jibx/binding/Utility.java
+++ b/build/src/org/jibx/binding/Utility.java
@@ -187,7 +187,7 @@ public class Utility
      */
     public static String fileName(String path) {
         if (File.separatorChar != '/') {
-            path = path.replace('/', File.separatorChar);
+            path = path.replaceAll('/', File.separatorChar);
         }
         int split = path.lastIndexOf(File.separatorChar);
         return path.substring(split+1);


### PR DESCRIPTION
Before this fix, if a path to binding file
contains multiple directories, and if "/"
is used as separator in path, method
fileName(String path) from
org.jibx.binding.Utility class which should
extract base file name from a full path will
replace only first "/" character in path with
operating system file separator, instead of
all "/" characters, leaving rest of the logic
broken on Windows.

This issue is root cause of a build issue
in Spring framework
https://jira.springsource.org/browse/SPR-8360

This patch fixes the issue by replacing
all "/" chacracters in the path with
OS specific file separator.

Issue: JIBX-441
