### PR TITLE
fix source tracking bytecode enhancement

### DIFF
--- a/build/src/org/jibx/binding/def/ObjectBinding.java
+++ b/build/src/org/jibx/binding/def/ObjectBinding.java
@@ -592,7 +592,7 @@ implements IComponent, IContextObj
      * information, and also adds the appropriate interfaces to the class.
      */
     private void genTrackSourceCode() {
-    	if (m_class.isDirectAccess()) {
+    	if (m_class.isLimitedDirectAccess()) {
 	        ClassFile cf = m_class.getDirectMungedFile();
 	        if (!cf.isAbstract() &&
 	            cf.addInterface(SOURCE_TRACKING_INTERFACE)) {


### PR DESCRIPTION
Source tracking was broken for JVM 7 and JVM 8.

Relates to Issue https://github.com/jibx/jibx/issues/7

Minimalist maven project for reproducing the issue: https://github.com/lpetit-yseop/jibx-track-source-issue (see `README.adoc`)