### PR TITLE
Add support for Unicode supplementary plane codepoints

### DIFF
--- a/build/src/org/jibx/runtime/impl/ISO88591Escaper.java
+++ b/build/src/org/jibx/runtime/impl/ISO88591Escaper.java
@@ -63,9 +63,10 @@ public class ISO88591Escaper implements ICharacterEscaper
      */
 
     public void writeAttribute(String text, Writer writer) throws IOException {
+        int chr;
         int mark = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '"') {
                 writer.write(text, mark, i-mark);
                 mark = i+1;
@@ -91,7 +92,7 @@ public class ISO88591Escaper implements ICharacterEscaper
             } else if (chr >= 0x80) {
                 if (chr < 0xA0 || chr > 0xFF) {
                     writer.write(text, mark, i-mark);
-                    mark = i+1;
+                    mark = i+Character.charCount(chr);
                     if (chr > 0xD7FF && (chr < 0xE000 || chr == 0xFFFE ||
                         chr == 0xFFF || chr > 0x10FFFF)) {
                         throw new IOException("Illegal character code 0x" +
@@ -116,9 +117,10 @@ public class ISO88591Escaper implements ICharacterEscaper
      */
 
     public void writeContent(String text, Writer writer) throws IOException {
+        int chr;
         int mark = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '&') {
                 writer.write(text, mark, i-mark);
                 mark = i+1;
@@ -140,7 +142,7 @@ public class ISO88591Escaper implements ICharacterEscaper
             } else if (chr >= 0x80) {
                 if (chr < 0xA0 || chr > 0xFF) {
                     writer.write(text, mark, i-mark);
-                    mark = i+1;
+                    mark = i+Character.charCount(chr);
                     if (chr > 0xD7FF && (chr < 0xE000 || chr == 0xFFFE ||
                         chr == 0xFFF || chr > 0x10FFFF)) {
                         throw new IOException("Illegal character code 0x" +
@@ -166,9 +168,10 @@ public class ISO88591Escaper implements ICharacterEscaper
      */
 
     public void writeCData(String text, Writer writer) throws IOException {
+        int chr;
         writer.write("<![CDATA[");
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '>' && i > 2 && text.charAt(i-1) == ']' &&
                 text.charAt(i-2) == ']') {
                 throw new IOException("Sequence \"]]>\" is not allowed " +

--- a/build/src/org/jibx/runtime/impl/USASCIIEscaper.java
+++ b/build/src/org/jibx/runtime/impl/USASCIIEscaper.java
@@ -63,9 +63,10 @@ public class USASCIIEscaper implements ICharacterEscaper
      */
 
     public void writeAttribute(String text, Writer writer) throws IOException {
+        int chr;
         int mark = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '"') {
                 writer.write(text, mark, i-mark);
                 mark = i+1;
@@ -90,7 +91,7 @@ public class USASCIIEscaper implements ICharacterEscaper
                 }
             } else if (chr > 0x7F) {
                 writer.write(text, mark, i-mark);
-                mark = i+1;
+                mark = i+Character.charCount(chr);
                 if (chr > 0xD7FF && (chr < 0xE000 || chr == 0xFFFE ||
                     chr == 0xFFFF || chr > 0x10FFFF)) {
                     throw new IOException("Illegal character code 0x" +
@@ -113,9 +114,10 @@ public class USASCIIEscaper implements ICharacterEscaper
      */
 
     public void writeContent(String text, Writer writer) throws IOException {
+        int chr;
         int mark = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '&') {
                 writer.write(text, mark, i-mark);
                 mark = i+1;
@@ -136,7 +138,7 @@ public class USASCIIEscaper implements ICharacterEscaper
                 }
             } else if (chr > 0x7F) {
                 writer.write(text, mark, i-mark);
-                mark = i+1;
+                mark = i+Character.charCount(chr);
                 if (chr > 0xD7FF && (chr < 0xE000 || chr == 0xFFFE ||
                     chr == 0xFFFF || chr > 0x10FFFF)) {
                     throw new IOException("Illegal character code 0x" +
@@ -161,9 +163,10 @@ public class USASCIIEscaper implements ICharacterEscaper
      */
 
     public void writeCData(String text, Writer writer) throws IOException {
+        int chr;
         writer.write("<![CDATA[");
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '>' && i > 2 && text.charAt(i-1) == ']' &&
                 text.charAt(i-2) == ']') {
                 throw new IOException("Sequence \"]]>\" is not allowed " +

--- a/build/src/org/jibx/runtime/impl/UTF8Escaper.java
+++ b/build/src/org/jibx/runtime/impl/UTF8Escaper.java
@@ -64,9 +64,10 @@ public class UTF8Escaper implements ICharacterEscaper
      */
 
     public void writeAttribute(String text, Writer writer) throws IOException {
+        int chr;
         int mark = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '"') {
                 writer.write(text, mark, i-mark);
                 mark = i+1;
@@ -107,9 +108,10 @@ public class UTF8Escaper implements ICharacterEscaper
      */
 
     public void writeContent(String text, Writer writer) throws IOException {
+        int chr;
         int mark = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '&') {
                 writer.write(text, mark, i-mark);
                 mark = i+1;
@@ -149,8 +151,9 @@ public class UTF8Escaper implements ICharacterEscaper
 
     public void writeCData(String text, Writer writer) throws IOException {
         writer.write("<![CDATA[");
-        for (int i = 0; i < text.length(); i++) {
-            char chr = text.charAt(i);
+        int chr;
+        for (int i = 0; i < text.length(); i += Character.charCount(chr)) {
+            chr = text.codePointAt(i);
             if (chr == '>' && i > 2 && text.charAt(i-1) == ']' &&
                 text.charAt(i-2) == ']') {
                 throw new IOException("Sequence \"]]>\" is not allowed " +                    "within CDATA section text");


### PR DESCRIPTION
The Unicode supplementary plane code points U+10000–U+10FFFF are valid XML 1.0 characters ([reference](https://en.wikipedia.org/wiki/Valid_characters_in_XML#XML_1.0)), and they are supported by Java since JDK 1.5, but JiBX doesn't seem to support them:

```
Caused by: java.io.IOException: Illegal character code 0xd83c in content text
        at org.jibx.runtime.impl.UTF8Escaper.writeContent(UTF8Escaper.java:134)
        at org.jibx.runtime.impl.GenericXMLWriter.writeTextContent(GenericXMLWriter.java:221)
        at org.jibx.runtime.impl.MarshallingContext.element(MarshallingContext.java:729)
        ... 82 more

```

This patch fixes that.