### PR TITLE
option 1.3 is no longer supported. Use 6 or later in doc

### DIFF
--- a/build/docs/build.xml
+++ b/build/docs/build.xml
@@ -30,7 +30,7 @@
     <delete dir="${classes}" quiet="true"/>
     <mkdir dir="${classes}"/>
     <echo message="Compiling the java source files..."/>
-    <javac srcdir="src" destdir="${classes}" debug="on" includes="**/*.java" source="1.3" target="1.3">
+    <javac srcdir="src" destdir="${classes}" debug="on" includes="**/*.java" source="1.6" target="1.6">
       <classpath>
         <pathelement location="${classes}"/>
         <pathelement location="${jibx-lib}/jibx-run.jar"/>

--- a/build/src/org/jibx/binding/classes/ClassFile.java
+++ b/build/src/org/jibx/binding/classes/ClassFile.java
@@ -326,6 +326,7 @@ public class ClassFile
      */
     private void init(String name, String path, InputStream ins)
         throws JiBXException {
+      try{
         m_name = name;
         m_signature = Utility.getSignature(name);
         m_type = ClassItem.typeFromName(name);
@@ -344,6 +345,17 @@ public class ClassFile
             } catch (Exception ex) {
                 throw new JiBXException("Error reading path " +
                     path + " for class " + name);
+                }
+        }
+      }
+      finally {
+        if (null != ins) {
+          try {
+            ins.close();
+          }
+          catch (IOException ex) {
+            throw new JiBXException("could not close:" + ins + "while reading path " + path + " for class " + name + " because:" + ex);
+          }
             }
         }
         initInterface();


### PR DESCRIPTION
on an Ubuntu 18.04 system (Linux ubuntu 4.15.0-135-generic) building jibx fails (java version OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.10+9, mixed mode).
